### PR TITLE
Add support for showing the Currently happening session, and related UI tweaks

### DIFF
--- a/DeepDishLie/Controllers/ScheduleController.swift
+++ b/DeepDishLie/Controllers/ScheduleController.swift
@@ -46,6 +46,17 @@ class ScheduleController {
         }
     }
 
+    var currentDateEvent: Event? {
+        for day in days {
+            for event in day.events {
+                if event.isHappeningNow {
+                    return event
+                }
+            }
+        }
+        return nil
+    }
+
     private func chunkUpEvents(_ events: [Event]) -> [Day] {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "EEEE"

--- a/DeepDishLie/Controllers/WelcomeController.swift
+++ b/DeepDishLie/Controllers/WelcomeController.swift
@@ -10,11 +10,13 @@ import SwiftUI
 @Observable
 class WelcomeController {
     var hasSeenWelcome: Bool { didSet { UserDefaults.standard.set(hasSeenWelcome, forKey: "has-seen-welcome-2024") }}
+    var hasRequestedReview: Bool { didSet { UserDefaults.standard.set(hasRequestedReview, forKey: "has-seen-review-2024") }}
     var showsWelcome = false
     var hasJustSeenWelcome = false
 
     init() {
         self.hasSeenWelcome = UserDefaults.standard.bool(forKey: "has-seen-welcome-2024")
+        self.hasRequestedReview = UserDefaults.standard.bool(forKey: "has-seen-review-2024")
     }
 }
 

--- a/DeepDishLie/Views/ScheduleView.swift
+++ b/DeepDishLie/Views/ScheduleView.swift
@@ -213,23 +213,13 @@ private struct EventRow: View {
     }
 
     private var listRowBackgroundColor: Color? {
-        if event.isHappeningNow {
-            return Color.accentColor
+        guard event.isHappeningNow else {
+            return switch event {
+            case .session: nil
+            default: Color.accentColor.opacity(0.1)
+            }
         }
-        return switch event {
-        case .practical:
-            Color.accentColor.opacity(0.1)
-        case .session:
-            nil
-        case .special:
-            Color.accentColor.opacity(0.1)
-        case .pause:
-            Color.accentColor.opacity(0.1)
-        case .breakfast:
-            Color.accentColor.opacity(0.1)
-        case .lunch:
-            Color.accentColor.opacity(0.1)
-        }
+        return Color.accentColor
     }
 
     private var dateFrameDivider: CGFloat {

--- a/DeepDishLie/Views/ScheduleView.swift
+++ b/DeepDishLie/Views/ScheduleView.swift
@@ -266,22 +266,22 @@ private struct EventRow: View {
 
 extension Event {
     var isHappeningNow: Bool {
-        self.start...end ~= Date()
+        start ... end ~= Date()
     }
 
     var dateTextColor: Color {
         if isHappeningNow {
-            return Color(uiColor: UIColor.lightText)
+            .init(uiColor: UIColor.lightText)
         } else {
-            return .accentColor
+            .accentColor
         }
     }
 
     var titleTextColor: Color {
         if isHappeningNow {
-            return Color(uiColor: UIColor.systemBackground)
+            .init(uiColor: UIColor.systemBackground)
         } else {
-            return Color.primary//(uiColor: UIColor.)
+            .primary
         }
     }
 }

--- a/DeepDishLie/Views/ScheduleView.swift
+++ b/DeepDishLie/Views/ScheduleView.swift
@@ -164,7 +164,7 @@ private struct EventRow: View {
                         .foregroundStyle(event.titleTextColor)
                     if let speakers = event.speakers {
                         Text(ListFormatter.localizedString(byJoining: speakers.map(\.name)))
-                            .foregroundStyle(event.titleTextColor)
+                            .foregroundStyle(event.subtitleTextColor)
                     }
                 }
                 if let speakers = event.speakers {
@@ -271,6 +271,14 @@ extension Event {
             .init(uiColor: UIColor.systemBackground)
         } else {
             .primary
+        }
+    }
+    
+    var subtitleTextColor: Color {
+        if isHappeningNow {
+            .init(uiColor: UIColor.systemBackground)
+        } else {
+            .secondary
         }
     }
 }

--- a/DeepDishLie/Views/ScheduleView.swift
+++ b/DeepDishLie/Views/ScheduleView.swift
@@ -44,8 +44,8 @@ struct ScheduleView: View {
                 .toolbarBackground(.visible, for: .navigationBar)
                 .toolbarColorScheme(.dark, for: .navigationBar)
                 .toolbar {
-                    HStack {
-                        if let currentDateId {
+                    if let currentDateId {
+                        ToolbarItem(placement: .topBarLeading) {
                             Button {
                                 withAnimation {
                                     proxy.scrollTo(currentDateId, anchor: .center)
@@ -54,6 +54,8 @@ struct ScheduleView: View {
                                 Label("Now", systemImage: "clock")
                             }
                         }
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
                         Button {
                             showsSettings = true
                         } label: {
@@ -273,7 +275,7 @@ extension Event {
             .primary
         }
     }
-    
+
     var subtitleTextColor: Color {
         if isHappeningNow {
             .init(uiColor: UIColor.systemBackground)

--- a/DeepDishLie/Views/ScheduleView.swift
+++ b/DeepDishLie/Views/ScheduleView.swift
@@ -153,7 +153,6 @@ private struct EventRow: View {
                     Text(dateFormatter.string(from: event.start))
                     Text(dateFormatter.string(from: event.end))
                 }
-                .padding(.trailing, 2)
                 .font(.subheadline)
                 .fontWeight(.semibold)
                 .foregroundStyle(event.dateTextColor)

--- a/DeepDishLie/Views/ScheduleView.swift
+++ b/DeepDishLie/Views/ScheduleView.swift
@@ -11,15 +11,13 @@ import SwiftUI
 
 struct ScheduleView: View {
     @State private var timer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
-
+    @State private var currentDateId: String?
     @State private var showsSettings = false
     @State private var toolbarRerenderTrigger = false
     @Environment(\.requestReview) private var requestReview
     @Environment(WelcomeController.self) private var welcomeController
     @Environment(SettingsController.self) private var settingsController
     @Environment(ScheduleController.self) private var scheduleController
-
-    @State private var currentDateID: String?
 
     var body: some View {
         let dateFormatter = Event.dateFormatter(useLocalTimezone: settingsController.useLocalTimezone, use24hourClock: settingsController.use24hourClock)
@@ -47,10 +45,10 @@ struct ScheduleView: View {
                 .toolbarColorScheme(.dark, for: .navigationBar)
                 .toolbar {
                     HStack {
-                        if let currentDateID {
+                        if let currentDateId {
                             Button {
                                 withAnimation {
-                                    proxy.scrollTo(currentDateID, anchor: .center)
+                                    proxy.scrollTo(currentDateId, anchor: .center)
                                 }
                             } label: {
                                 Label("Now", systemImage: "clock")
@@ -71,9 +69,9 @@ struct ScheduleView: View {
                     SettingsView()
                 }
                 .onAppear {
-                    currentDateID = scheduleController.currentDateEvent?.id
-                    if let currentDateID {
-                        proxy.scrollTo(currentDateID, anchor: .center)
+                    currentDateId = scheduleController.currentDateEvent?.id
+                    if let currentDateId {
+                        proxy.scrollTo(currentDateId, anchor: .center)
                     }
                     if welcomeController.hasSeenWelcome, !welcomeController.hasRequestedReview {
                         welcomeController.hasRequestedReview = true
@@ -130,8 +128,9 @@ struct ScheduleView: View {
                            closingAngle: .degrees(0),
                            radius: 160,
                            repetitionInterval: 1)
-        }.onReceive(timer) { _ in
-            currentDateID = scheduleController.currentDateEvent?.id
+        }
+        .onReceive(timer) { _ in
+            currentDateId = scheduleController.currentDateEvent?.id
         }
     }
 }


### PR DESCRIPTION
- The currently active Event is now highlighted in red with changed text colors
- Reduced variation of background colors so the current event stands out more
- On first launch the current event is now scrolled to (if it exists)
- Added a time button in the navbar to scroll to the current event (if it exists)
- Fixed issue where request for review is attempted at every launch, causing a periodic UI hang (at least in the Simulator)